### PR TITLE
Update and rename index.html to color=”#4aa956"

### DIFF
--- a/src/color=”#4aa956"
+++ b/src/color=”#4aa956"
@@ -51,7 +51,7 @@
 
     <!-- common pwa settings -->
     <link rel="icon" href="./assets/favicon/logo.svg"/>
-    <link rel="mask-icon" href="./assets/favicon/favicon.svg" color=”#4aa956"/>
+    <link rel="mask-icon" href="./assets/favicon/favicon.svg" color="#4aa956"/>
     <link rel="manifest" href="./manifest.json"/>
     <meta name="theme-color" content="#1e1e1e"/>
     <!-- common pwa settings -->


### PR DESCRIPTION
<img width="631" alt="Снимок экрана 2024-11-01 в 12 23 56" src="https://github.com/user-attachments/assets/8ddc7d25-f5ae-497f-aebc-58caaf8388d3">

The incorrect quotes around the color. Standard double quotes `"` should be used instead of typographic quotes `”.`

Fixed.